### PR TITLE
Add optional libSQL encryption support to MemoryStore

### DIFF
--- a/packages/sdk/src/store.ts
+++ b/packages/sdk/src/store.ts
@@ -84,6 +84,7 @@ export class MemoryStore {
   private readonly topK: number;
   private readonly learningRate: number;
   private readonly decayRate: number;
+  private readonly encryption?: MemelordConfig["encryption"];
 
   constructor(config: MemelordConfig) {
     this.dbPath = config.dbPath;
@@ -93,6 +94,7 @@ export class MemoryStore {
     this.topK = config.topK ?? 5;
     this.learningRate = config.learningRate ?? 0.1;
     this.decayRate = config.decayRate ?? 0.995;
+    this.encryption = config.encryption;
   }
 
   /**
@@ -110,7 +112,8 @@ export class MemoryStore {
     for (let attempt = 0; ; attempt++) {
       try {
         db = await connect(this.dbPath, {
-          experimental: ["multiprocess_wal"]
+          experimental: ["multiprocess_wal"],
+          ...(this.encryption ? { encryption: this.encryption } : {})
         });
         break;
       } catch (e: any) {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -25,6 +25,21 @@ export interface MemelordConfig {
   learningRate?: number;
   /** Daily decay rate for unused memories (default: 0.995) */
   decayRate?: number;
+  /**
+   * Optional local encryption configuration for the underlying libSQL database.
+   * Supported ciphers mirror the libSQL embedded driver.
+   */
+  encryption?: {
+    cipher:
+      | "aes128gcm"
+      | "aes256gcm"
+      | "aegis256"
+      | "aegis256x2"
+      | "aegis128l"
+      | "aegis128x2"
+      | "aegis128x4";
+    hexkey: string;
+  };
 }
 
 export interface Memory {


### PR DESCRIPTION
This PR adds an optional `encryption` field to `MemelordConfig` and forwards it to the underlying `@tursodatabase/database` `connect()` call.

### What changed

- `packages/sdk/src/types.ts`: added `encryption?: { cipher: ...; hexkey: string }` to `MemelordConfig`. The cipher list matches the `EncryptionCipher` type in the libSQL TypeScript bindings (`aes128gcm`, `aes256gcm`, `aegis256`, `aegis256x2`, `aegis128l`, `aegis128x2`, `aegis128x4`).
- `packages/sdk/src/store.ts`: stored `this.encryption` and passed it through to `connect()`.

### Why

This allows consumers to create encrypted libSQL memory databases, which is useful for per-user or per-principal memory isolation.

### Open question

I inlined the encryption type in `MemelordConfig` to avoid adding a direct dependency on `@tursodatabase/database-common`. Would you prefer to import `EncryptionOpts` from `@tursodatabase/database-common` instead?

### Backwards compatibility

The `encryption` field is optional, so existing consumers are unaffected.

### Verification

- `bunx tsc -p tsconfig.build.json --noEmit` passes.
- No new runtime dependencies.